### PR TITLE
Gracefully degrade when People Finder is unavailable

### DIFF
--- a/app/models/people_finder_profile.rb
+++ b/app/models/people_finder_profile.rb
@@ -31,7 +31,7 @@ class PeopleFinderProfile
         }
       )
 
-      response = JSON.parse(response.body)
+      response = response.success? ? JSON.parse(response.body) : {}
       @links = response['data'] ? response['data']['links'] : {}
       @attributes = response['data'] ? response['data']['attributes'] : {}
     end

--- a/spec/models/people_finder_profile_spec.rb
+++ b/spec/models/people_finder_profile_spec.rb
@@ -4,71 +4,87 @@ describe PeopleFinderProfile do
   describe '#from_api' do
     let(:user) { AuthUser.new(email: 'alice@example.com') }
 
-    before do
-      response = double(:response, body: people_finder_hash)
-
-      allow(HTTParty)
-        .to receive(:get)
-        .and_return(response)
-    end
-
     subject { described_class.from_api(user) }
 
-    context 'with an existing people finder profile' do
-      let(:people_finder_hash) { existing_user_json }
+    context 'for a successful request' do
+      before do
+        response = double(:response, body: people_finder_hash, success?: true)
 
-      it 'assigns the name' do
-        expect(subject.name).to eq('Alice Arnold')
+        allow(HTTParty)
+          .to receive(:get)
+          .and_return(response)
       end
 
-      it 'assigns the team' do
-        expect(subject.team).to eq('Scientists')
-      end
-
-      it 'assigns the completion_score' do
-        expect(subject.completion_score).to eq(12)
-      end
-
-      it 'assigns the profile_image_url' do
-        expect(subject.profile_image_url).to eq('alice-image-url')
-      end
-
-      it 'assigns the profile_url' do
-        expect(subject.profile_url)
-          .to eq("#{ENV['PEOPLEFINDER_URL']}/my/profile")
-      end
-
-      context 'when the parameter is an email address' do
-        let(:user) { 'alice@example.com' }
+      context 'with an existing people finder profile' do
+        let(:people_finder_hash) { existing_user_json }
 
         it 'assigns the name' do
           expect(subject.name).to eq('Alice Arnold')
         end
+
+        it 'assigns the team' do
+          expect(subject.team).to eq('Scientists')
+        end
+
+        it 'assigns the completion_score' do
+          expect(subject.completion_score).to eq(12)
+        end
+
+        it 'assigns the profile_image_url' do
+          expect(subject.profile_image_url).to eq('alice-image-url')
+        end
+
+        it 'assigns the profile_url' do
+          expect(subject.profile_url)
+            .to eq("#{ENV['PEOPLEFINDER_URL']}/my/profile")
+        end
+
+        context 'when the parameter is an email address' do
+          let(:user) { 'alice@example.com' }
+
+          it 'assigns the name' do
+            expect(subject.name).to eq('Alice Arnold')
+          end
+        end
+      end
+
+      context 'when that person is not found in peoplefinder' do
+        let(:people_finder_hash) { user_not_found }
+
+        it 'does not assign the name' do
+          expect(subject.name).to be_blank
+        end
+
+        it 'does not assign the team' do
+          expect(subject.team).to be_blank
+        end
+
+        it 'assigns the completion_score to zero' do
+          expect(subject.completion_score).to eq(0)
+        end
+
+        it 'does not assign the profile_image_url' do
+          expect(subject.profile_image_url).to be_blank
+        end
+
+        it 'assigns the profile_url to the peoplefinder URL' do
+          expect(subject.profile_url)
+            .to eq("#{ENV['PEOPLEFINDER_URL']}/my/profile")
+        end
       end
     end
 
-    context 'when that person is not found in peoplefinder' do
-      let(:people_finder_hash) { user_not_found }
+    context 'when the People Finder does not return a response' do
+      let(:response) { double('Response', success?: false, body: 'Internal server error') }
+
+      before do
+        allow(HTTParty)
+          .to receive(:get)
+          .and_return(response)
+      end
 
       it 'does not assign the name' do
         expect(subject.name).to be_blank
-      end
-
-      it 'does not assign the team' do
-        expect(subject.team).to be_blank
-      end
-
-      it 'assigns the completion_score to zero' do
-        expect(subject.completion_score).to eq(0)
-      end
-
-      it 'does not assign the profile_image_url' do
-        expect(subject.profile_image_url).to be_blank
-      end
-
-      it 'assigns the profile_url to the peoplefinder URL' do
-        expect(subject.profile_url)
-          .to eq("#{ENV['PEOPLEFINDER_URL']}/my/profile")
       end
     end
   end


### PR DESCRIPTION
This adds a check to `PeopleFinderProfile` to catch when a response from the People Finder was not successful.

When it isn't successful, it returns an empty profile, which is consistent with the behaviour for when a profile does not exist.