### PR TITLE
Insert the page title into the <title> tag

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,4 +38,10 @@ module ApplicationHelper
     text = count == 1 ? 'comment' : 'comments'
     "#{count} #{text}"
   end
+
+  def page_title
+    (
+      [@page_title] << 'Digital Workspace'
+    ).compact.join(' - ')
+  end
 end

--- a/app/views/accordion/index.html.haml
+++ b/app/views/accordion/index.html.haml
@@ -28,7 +28,7 @@
         - if @accordion.present?
           - @accordion.each do |page|
             %h2.heading-large
-              = page["title"]["rendered"].html_safe
+              = @page_title = page["title"]["rendered"].html_safe
             %div
               = page["acf"]["excerpt"].html_safe
 

--- a/app/views/archive/index.html.haml
+++ b/app/views/archive/index.html.haml
@@ -33,7 +33,7 @@
       .column-full
         %hr{:class => 'rule-large rule-top'}
         %h2.heading-medium
-          All news
+          = @page_title = "All news"
     .grid-row
       - if @hero_post
         .column-full

--- a/app/views/archive/news_type.html.haml
+++ b/app/views/archive/news_type.html.haml
@@ -36,7 +36,7 @@
       .column-full
         %hr{:class => 'rule-large rule-top'}
         %h2.heading-medium
-          = news_cat_title
+          = @page_title = news_cat_title
     .grid-row
       - if @hero_post
         .column-full

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 - content_for :body_start do
   = render partial: "widgets/notifications"
 
-- content_for :page_title, "Digital Workspace"
+- content_for :page_title, page_title
 
 - content_for :homepage_url do
   = '/'

--- a/app/views/search/index.html.haml
+++ b/app/views/search/index.html.haml
@@ -42,7 +42,7 @@
       .grid-row
         .column-full
           %h2.heading-large
-            Search results for '#{@string}'
+            = @page_title = "Search results for '#{@string}''"
       .grid-row
         .column-third
           %p.info

--- a/app/views/single/index.html.haml
+++ b/app/views/single/index.html.haml
@@ -10,7 +10,7 @@
     .grid-row
       .column-full
         %h2.heading-medium
-          = @slug
+          = @page_title = @slug
     .grid-row
       .column-full
         - if @posts.present?

--- a/app/views/single/news.html.haml
+++ b/app/views/single/news.html.haml
@@ -48,7 +48,7 @@
           .news-item
             %h2.heading-large
               %hr{:class => 'rule-small'}
-              = p["title"]["rendered"].html_safe
+              = @page_title = p["title"]["rendered"].html_safe
             .post-meta
               - profile = PeopleFinderProfile.from_api(p["author_email"])
               = succeed ', ' do

--- a/app/views/topics/index.html.haml
+++ b/app/views/topics/index.html.haml
@@ -38,7 +38,7 @@
         - if @topic.present?
           - @topic.each do |topic|
             %h2.heading-large
-              = topic["title"]["rendered"].html_safe
+              = @page_title = topic["title"]["rendered"].html_safe
             = topic["content"]["rendered"].html_safe
 
         %hr{:class => 'rule-small'}

--- a/app/views/widgets/_content_partial.html.haml
+++ b/app/views/widgets/_content_partial.html.haml
@@ -21,7 +21,7 @@
                 %p
                   This policy is being updated. It is current, but will soon be replaced.
             %h2.heading-large.heading-top
-              = content["title"]["rendered"].html_safe
+              = @page_title = content["title"]["rendered"].html_safe
             - if content["acf"]["policy_or_guidance"].present?
               %p.policy-type
                 = content["acf"]["policy_or_guidance"]


### PR DESCRIPTION
This changes the application layout to allow the `<title>` tag to be set by individual pages, and modifies existing content views to set the `@page_title` variable to that of the main page heading.

This approach and styling is consistent with the People Finder.