### PR TITLE
A few visual tweaks to news listings and site text. 

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,6 +55,7 @@
 @import "vars/screen-sizes";
 @import "vars/colours";
 @import "vars/assets";
+@import "vars/typography-sizes";
 
 // ---------------------------------------
 // Utilites

--- a/app/assets/stylesheets/components/_beta-bar.scss
+++ b/app/assets/stylesheets/components/_beta-bar.scss
@@ -16,8 +16,8 @@
 		padding: 2px 5px 0;
 		font-weight: 700;
 		text-transform: none;
-		font-size: 16px;
-		line-height: 1.14286;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		text-transform: uppercase;
 		letter-spacing: 1px;
 		text-decoration: none;
@@ -45,7 +45,7 @@
 
 @media (min-width: $screen_medium) {
 	.beta-bar {
-		font-size: 16px;
+		font-size: $text_xsmall;
 		.beta-label {
 			float: none;
 			margin-bottom: 0;

--- a/app/assets/stylesheets/components/_beta-label.scss
+++ b/app/assets/stylesheets/components/_beta-label.scss
@@ -8,7 +8,7 @@
 	//font-family: $font_family_main;
 	font-weight: 700;
 	text-transform: none;
-	font-size: 16px;
+	font-size: $text_xsmall;
 	line-height: 1;
 	text-transform: uppercase;
 	letter-spacing: 1px;

--- a/app/assets/stylesheets/components/_breadcrumb.scss
+++ b/app/assets/stylesheets/components/_breadcrumb.scss
@@ -8,8 +8,7 @@ ul.breadcrumb {
 		position: relative;
 		display: inline-block;
 		padding: 0px 14px;
-		font-size: 16px;
-
+		font-size: $text_xsmall;
 		a {
 			color: #000000;
 		}

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -12,13 +12,15 @@
 
 	.footer-meta-inner {
 		li {
-			font-size: 16px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 		}
 	}
 
 	.acknowledgements {
 		p {
-			font-size: 16px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 			margin-bottom: 0px;
 		}
 	}

--- a/app/assets/stylesheets/components/_global-notifications.scss
+++ b/app/assets/stylesheets/components/_global-notifications.scss
@@ -3,8 +3,8 @@
 
 	p {
 		position: relative;
-		font-size: 16px;
-		line-height: 22px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		margin: 0;
 		color: #FFFFFF;
 		padding: 10px 0px 10px 65px;

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -118,7 +118,8 @@
 		}
 		.paging-count {
 			display: block;
-			font-size: 16px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 			text-decoration: underline;
 		}
 	}

--- a/app/assets/stylesheets/components/_post-meta.scss
+++ b/app/assets/stylesheets/components/_post-meta.scss
@@ -2,7 +2,8 @@
 	color: #6f777b;
 	margin-top: 10px;
 	margin-bottom: 10px;
-	font-size: 16px;
+	font-size: $text_xsmall;
+	line-height: 1.25;
 
 	@media(min-width: $screen_medium) {
 		margin-top: 20px;

--- a/app/assets/stylesheets/components/_search-results.scss
+++ b/app/assets/stylesheets/components/_search-results.scss
@@ -26,7 +26,8 @@
 
 	.result-count {
 		color: #454a4c;
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 	}
 
 	.heading-large {
@@ -35,7 +36,8 @@
 
 	p.info {
 		color: #454a4c;
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		margin-top: 0;
 	}
 
@@ -46,7 +48,7 @@
 			padding: 5px;
 			.legend {
 				font-family: "nta", Arial, sans-serif;
-				font-size: 16px;
+				font-size: $text_xsmall;
 				line-height: 1.25;
 				font-weight: 400;
 				text-transform: none;
@@ -101,7 +103,8 @@
 				label {
 					display: -moz-inline-stack;
 					display: inline-block;
-					font-size: 16px;
+					font-size: $text_xsmall;
+					line-height: 1.25;
 					margin-left: 20px;
 				}
 			}
@@ -125,7 +128,8 @@
 					.clear-selected {
 						display: -moz-inline-stack;
 						display: inline-block;
-						font-size: 16px;
+						font-size: $text_xsmall;
+						line-height: 1.25;
 						margin-right: 5px;
 						&.js-hidden {
 							left: -9999em;
@@ -179,7 +183,7 @@
 			.filter {
 				.legend {
 					font-size: 19px;
-					line-height: 1.31579;
+					line-height: 1.251579;
 				}
 			}
 		}

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -35,7 +35,7 @@
 		font-family: $font_family_main;
 		font-weight: 400;
 		text-transform: none;
-		font-size: 16px !important; /* override */
+		font-size: $text_xsmall !important; /* override */
 		line-height: 1.75;
 		background: #fff;
 		border-radius: 0;
@@ -85,7 +85,7 @@
 			font-family: $font_family_main;
 			font-weight: 400;
 			text-transform: none;
-			font-size: 16px;
+			font-size: $text_xsmall;
 			line-height: 40px;
 			color: #6f777b;
 		}

--- a/app/assets/stylesheets/components/_typography.scss
+++ b/app/assets/stylesheets/components/_typography.scss
@@ -1,11 +1,5 @@
 /* Typography */
 
-$text_large		: 36px;
-$text_medium	: 24px;
-$text_small		: 19px;
-$text_xsmall	: 16px;
-$text_xxsmall	: 12px;
-
 h1,
 .heading-large {
 	font-size: $text_large;

--- a/app/assets/stylesheets/pages/home/_homepage.scss
+++ b/app/assets/stylesheets/pages/home/_homepage.scss
@@ -115,7 +115,8 @@
 		width: 66.66667%
 	}
 	.heading-medium {
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		margin: 0;
 		//padding-top: 6px;
 		padding-top: 1.65em;
@@ -148,7 +149,8 @@
 			padding-bottom: 4px;
 		}
 		p {
-			font-size: 16px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 		}
 	}
 
@@ -224,8 +226,8 @@
 	}
 	.stat-description {
 		display: block;
-		font-size: 16px;
-		line-height: 19px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		font-weight: bold;
 		margin: 80px 0px 0px 0px;
 
@@ -239,7 +241,8 @@
 
 .howdoi-description {
 	display: block;
-	font-size: 16px;
+	font-size: $text_xsmall;
+	line-height: 1.25;
 	margin-top: 0;
 }
 
@@ -280,7 +283,8 @@
 .how-tos {
 	margin: 10px 0 0;
 	li {
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		margin-bottom: 12px;
 	}
 }
@@ -295,14 +299,16 @@
 	}
 	.tweet-body {
 		float: left;
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 		width: 83%;
 		.tweet-meta {
 			margin-left: 20px;
 		}
 		.tweet-content {
 			color: #6f777b;
-			font-size: 16px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 			margin-left: 20px;
 			padding-top: 4px;
 			a {

--- a/app/assets/stylesheets/pages/news/_news-comments.scss
+++ b/app/assets/stylesheets/pages/news/_news-comments.scss
@@ -1,5 +1,6 @@
 .cta-comment-reply {
-	font-size: 16px;
+	font-size: $text_xsmall;
+	line-height: 1.25;
 }
 
 .comment-replies {
@@ -30,7 +31,8 @@
 	padding: 20px;
 	margin: 0px 0px 20px 0px;
 	min-height: 100px;
-	font-size: 16px;
+	font-size: $text_xsmall;
+	line-height: 1.25;
 }
 
 .comment-notification {
@@ -59,7 +61,8 @@
 
 @media (min-width: $screen_medium) {
 	.comment-notification {
-		font-size: 16px;
+		font-size: $text_xsmall;
+		line-height: 1.25;
 	}
 }
 

--- a/app/assets/stylesheets/pages/news/_news-index.scss
+++ b/app/assets/stylesheets/pages/news/_news-index.scss
@@ -57,8 +57,15 @@
 
 .news-item-excerpt {
 	p {
-		font-size: $text_xsmall;
+		font-size: $text_small;
 		line-height: $text_medium;
+	}
+}
+
+.news-item-image-container {
+	max-width: 100%;
+	img {
+		max-width: 100%;
 	}
 }
 

--- a/app/assets/stylesheets/pages/standard/_standard-index.scss
+++ b/app/assets/stylesheets/pages/standard/_standard-index.scss
@@ -7,8 +7,8 @@
 
 	.card {
 		p {
-			font-size: 16px;
-			line-height: 24px;
+			font-size: $text_xsmall;
+			line-height: 1.25;
 		}
 	}
 }

--- a/app/assets/stylesheets/vars/_typography-sizes.scss
+++ b/app/assets/stylesheets/vars/_typography-sizes.scss
@@ -1,0 +1,5 @@
+$text_large		: 36px;
+$text_medium	: 24px;
+$text_small		: 19px;
+$text_xsmall	: 16px;
+$text_xxsmall	: 12px;

--- a/app/views/archive/index.html.haml
+++ b/app/views/archive/index.html.haml
@@ -81,7 +81,9 @@
                     - else
                       = news_cats( cat["name"], cat["slug"] ) + ', '
 
-
+                - if image_exists?(p)
+                  .news-item-image-container
+                    = large_image_tag(p)
                 .news-item-excerpt
                   %p
                     - if p["acf"].present?

--- a/app/views/archive/news_type.html.haml
+++ b/app/views/archive/news_type.html.haml
@@ -82,7 +82,9 @@
                     = news_cats( cat["name"], cat["slug"] )
                   - else
                     = news_cats( cat["name"], cat["slug"] ) + ', '
-
+            - if image_exists?(p)
+              .news-item-image-container
+                = large_image_tag(p)
             .news-item-excerpt
               %p
                 - if p["acf"].present?


### PR DESCRIPTION
Added line-height of 1.25 for any body text that's set at 16px as per GDS, increased news excerpt sizes to small instead of xsmall, added in images to news listings. DW-424, DW-426, DW-318