### PR TITLE
Improve People Finder health check

### DIFF
--- a/app/services/custom_health_check.rb
+++ b/app/services/custom_health_check.rb
@@ -25,7 +25,7 @@ class CustomHealthCheck
         'Authorization' => "Token token=#{ENV['PEOPLEFINDER_AUTH_TOKEN']}"
       }
     )
-    return if [404, 200].include?(response.code)
+    return if response['error'] =~ /person was not found/
 
     @errors << 'Unable to connect to the People Finder API'
   end


### PR DESCRIPTION
- Here we check that the API returns the expected 'not found' error message
when searching for a person that doesn't exist

- Previously we allowed a 404 error as there was several minutes of downtime
while the deployment was running.