### PR TITLE
Re-add deleted "How do I?" and "What's popular" blocks

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,7 @@ class HomeController < ApplicationController
   def index
     @api_call = HomePageQueries.new
     @posts = @api_call.main_query
+    @howdois = @api_call.howdois
+    @popular_posts = @api_call.popular_posts
   end
 end


### PR DESCRIPTION
For some reason some random front-end PR about IE8 accordions completely
deleted the backend code that populate the "How do I?" and "What's
popular?" sections on the Digital Workspace homepage:
https://github.com/uktrade/digital-workspace/pull/166

This adds the code back in (only these two sections for now). We should
evaluate why this was removed, and see whether we need to add some of
the other deleted code back in as well.