### PR TITLE
Add redirect from non-existing OAuth error page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   match '/auth/:provider/callback', to: 'sessions#create', via: %i[get post]
 
+  # On occasion, intermittent OAuth issues will cause users to be redirected to this path,
+  # which doesn't exist. This at least gets them to the homepage instead of a 404 page.
+  get '/auth/failure' => redirect('/')
+
   root to: 'home#index'
 
   get '/search/', to: 'search#index'


### PR DESCRIPTION
On occasion, intermittent OAuth issues (most likely an weird double
redirect) can cause users to end up on `/auth/failure`, a path that
doesn't exist. The nature of these issues makes them very difficult
to debug, so we should at least make sure the user is redirected to
the homepage, instead of being sent to a 404 page by our OAuth gem.