### PR TITLE
Redirect to originally visited URL after OAuth flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ end
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'pry'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
+    coderay (1.1.2)
     concurrent-ruby (1.1.3)
     connection_pool (2.2.1)
     crack (0.4.3)
@@ -179,6 +180,9 @@ GEM
     parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.6)
@@ -349,6 +353,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   omniauth-oauth2
+  pry
   puma (~> 3.7)
   rails (~> 5.2.1)
   rails_12factor

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ensure_sso_user
-    session[:auth_email] || redirect_to('/auth/ditsso_internal/')
+    session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{CGI.escape(request.fullpath)}")
   end
 
   def load_people_finder_profile

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,6 @@ class SessionsController < ApplicationController
   def create
     session[:auth_email] =
       AuthUser.from_omniauth_hash(request.env['omniauth.auth']).email
-    redirect_to '/'
+    redirect_to(request.env['omniauth.origin'] || '/')
   end
 end


### PR DESCRIPTION
Workspace currently redirects non-authenticated users to the homepage
after completing the OAuth flow. That's not very helpful - they may have
followed a specific link before being sent off to log in, and
`omniauth` does provide us with a way of tracking this "origin".