### PR TITLE
Add debug log for SSO redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ensure_sso_user
+    Rails.logger.info("ApplicationController#ensure_sso_user redirect?=<#{session[:auth_email].blank?}> path=<#{request.fullpath}>, encoding=<#{request.fullpath.encoding}>, encoded=<#{CGI.escape(request.fullpath)}>")
     session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{CGI.escape(request.fullpath)}")
   end
 


### PR DESCRIPTION
The recent change to redirect users after successful SSO sign in has
introduced an intermittent issue with users (apparently on IE11) being
sent to the Omniauth middleware with a bogus, seemingly ROT13-encoded
"origin" (redirect) URL.

We suspect this is an encoding issue, and this adds some rudimentary
logging around the redirect to allow us to see what is happening in
production.