### PR TITLE
Use ERB::Utils for SSO origin URL encoding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,8 +12,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ensure_sso_user
-    Rails.logger.info("ApplicationController#ensure_sso_user redirect?=<#{session[:auth_email].blank?}> path=<#{request.fullpath}>, encoding=<#{request.fullpath.encoding}>, encoded=<#{CGI.escape(request.fullpath)}>")
-    session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{CGI.escape(request.fullpath)}")
+    session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{ERB::Util.url_encode(request.fullpath)}")
   end
 
   def load_people_finder_profile


### PR DESCRIPTION
This does the URL encoding differently, so might avoid the ROT13 issue
we have been seeing.