### PR TITLE
Don't set Omniauth origin and rely on referrer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ensure_sso_user
-    session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{ERB::Util.url_encode(request.fullpath)}")
+    session[:auth_email] || redirect_to('/auth/ditsso_internal')
   end
 
   def load_people_finder_profile


### PR DESCRIPTION
Omniauth already uses the referrer if no origin was explicitly given,
and in light of the issues we are having with ROT13'd URLs coming
through, it's an acceptable tradeoff to have users with referrer
disabled sent to the homepage instead.