### PR TITLE
Refactor WpApi#get_json_body

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -26,6 +26,6 @@ class SearchController < ApplicationController
   end
 
   def working_at_dit_categories
-    WpApi.get_json_body('topic_taxonomy?per_page=100')
+    WpApi.get_json_body('topic_taxonomy', params: { per_page: 100 })
   end
 end

--- a/app/helpers/footer_menu_helper.rb
+++ b/app/helpers/footer_menu_helper.rb
@@ -1,6 +1,6 @@
 module FooterMenuHelper
   def footer_menu
-    WpApi.get_json_body('menus?slug=footer-menu')
+    WpApi.get_json_body('menus', params: { slug: 'footer-menu' })
   end
 
   def footer_menu_content

--- a/app/helpers/header_menu_helper.rb
+++ b/app/helpers/header_menu_helper.rb
@@ -1,6 +1,6 @@
 module HeaderMenuHelper
   def header_menu
-    WpApi.get_json_body('menus?slug=header-menu')
+    WpApi.get_json_body('menus', params: { slug: 'header-menu' })
   end
 
   def header_menu_content

--- a/app/helpers/news_helper.rb
+++ b/app/helpers/news_helper.rb
@@ -4,7 +4,7 @@ module NewsHelper
   end
 
   def news_cat_for_title
-    WpApi.get_json_body("news_categories/?slug=#{@slug}")
+    WpApi.get_json_body('news_categories', params: { slug: @slug })
   end
 
   def news_cat_title

--- a/app/models/accordion_queries.rb
+++ b/app/models/accordion_queries.rb
@@ -4,18 +4,18 @@ class AccordionQueries
   end
 
   def main_query(_slug)
-    WpApi.get_json_body("pages/?type=standard_index&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { type: 'standard_index', slug: @slug })
   end
 
   def accordion_theme_query(parent_slug)
-    WpApi.get_json_body("theme_taxonomy/?filter[theme_taxonomy]=#{parent_slug}")
+    WpApi.get_json_body('theme_taxonomy', params: { 'filter[theme_taxonomy]': parent_slug })
   end
 
   def self.accordion_theme_title_query(theme_slug)
-    WpApi.get_json_body("themes?slug=#{theme_slug}")
+    WpApi.get_json_body('themes', params: { slug: theme_slug })
   end
 
   def self.accordion_topic_query(theme_slug)
-    WpApi.get_json_body("topics/?filter[theme_taxonomy]=#{theme_slug}&orderby=title&order=asc")
+    WpApi.get_json_body('topics', params: { 'filter[theme_taxonomy]': theme_slug, orderby: 'title', order: 'asc' })
   end
 end

--- a/app/models/content_queries.rb
+++ b/app/models/content_queries.rb
@@ -1,5 +1,5 @@
 class ContentQueries
   def main_query
-    WpApi.get_json_body('pages?type=content')
+    WpApi.get_json_body('pages', params: { type: 'content' })
   end
 end

--- a/app/models/content_single_query.rb
+++ b/app/models/content_single_query.rb
@@ -4,10 +4,10 @@ class ContentSingleQuery
   end
 
   def notifications_query(_slug)
-    WpApi.get_json_body("pages?per_page=100&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { per_page: 100, slug: @slug })
   end
 
   def type_query
-    WpApi.get_json_body("pages?type=content&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { type: 'content', slug: @slug })
   end
 end

--- a/app/models/home_page_queries.rb
+++ b/app/models/home_page_queries.rb
@@ -1,36 +1,41 @@
 class HomePageQueries
   def popular_posts
     WpApi.get_json_body(
-      'popular_pages?orderby=menu_order&order=asc&per_page=3&_embed'
+      'popular_pages',
+      params: { orderby: 'menu_order', order: 'asc', per_page: 3, _embed: 1 }
     )
   end
 
   def posts_ministers
     WpApi.get_json_body(
-      'news?orderby=date&order=desc&per_page=2&filter[news_categories]=ministers&_embed'
+      'news',
+      params: { orderby: 'date', order: 'desc', per_page: 2, 'filter[news_categories]': 'ministers', _embed: 1 }
     )
   end
 
   def posts_antonia
     WpApi.get_json_body(
-      'news?orderby=date&order=desc&per_page=2&filter[news_categories]=antonia&_embed'
+      'news',
+      params: { orderby: 'date', order: 'desc', per_page: 2, 'filter[news_categories]': 'antonia', _embed: 1 }
     )
   end
 
   def posts_departmental
     WpApi.get_json_body(
-      'news?orderby=date&order=desc&per_page=2&filter[news_categories]=departmental&_embed'
+      'news',
+      params: { orderby: 'date', order: 'desc', per_page: 2, 'filter[news_categories]': 'departmental', _embed: 1 }
     )
   end
 
   def visualisations
-    WpApi.get_custom_json_body(
-      'visualisation'
-    )
+    WpApi.get_custom_json_body('visualisation')
   end
 
   def howdois
-    WpApi.get_json_body('howdoi?orderby=menu_order&order=desc&per_page=10')
+    WpApi.get_json_body(
+      'howdoi',
+      params: { orderby: 'menu_order', order: 'desc', per_page: 10 }
+    )
   end
 
   def main_query

--- a/app/models/howdoi_queries.rb
+++ b/app/models/howdoi_queries.rb
@@ -4,10 +4,10 @@ class HowdoiQueries
   end
 
   def howdoi_query
-    WpApi.get_json_body("howdoi?slug=#{@slug}")
+    WpApi.get_json_body('howdoi', params: { slug: @slug })
   end
 
   def topics_related_news
-    WpApi.get_json_body("news?filter[topic_taxonomy]=#{@slug}&per_page=5")
+    WpApi.get_json_body('news', params: { 'filter[topic_taxonomy]': @slug, per_page: 5 })
   end
 end

--- a/app/models/howdoi_query_all.rb
+++ b/app/models/howdoi_query_all.rb
@@ -1,13 +1,13 @@
 class HowdoiQueryAll
   def howdoi_1_100
-    WpApi.get_json_body('howdoi?orderby=menu_order&per_page=100')
+    WpApi.get_json_body('howdoi', params: { orderby: 'menu_order', per_page: 100 })
   end
 
   def howdoi_101_200
-    WpApi.get_json_body('howdoi?orderby=menu_order&per_page=100&offset=100')
+    WpApi.get_json_body('howdoi', params: { orderby: 'menu_order', per_page: 100, offset: 100 })
   end
 
   def howdoi_201_300
-    WpApi.get_json_body('howdoi?orderby=menu_order&per_page=100&offset=200')
+    WpApi.get_json_body('howdoi', params: { orderby: 'menu_order', per_page: 100, offset: 200 })
   end
 end

--- a/app/models/news_queries.rb
+++ b/app/models/news_queries.rb
@@ -1,7 +1,9 @@
 class NewsQueries
   def main_query(page)
-    path = "news?_embed&per_page=#{Paginator::PER_PAGE}&page=#{page}"
-    WpApi.get_json_body(path)
+    WpApi.get_json_body(
+      'news',
+       params: { _embed: 1, per_page: Paginator::PER_PAGE, page: page }
+    )
   end
 
   def main_query_headers(page)

--- a/app/models/news_type_queries.rb
+++ b/app/models/news_type_queries.rb
@@ -4,9 +4,10 @@ class NewsTypeQueries
   end
 
   def main_query(page)
-    path = "news?_embed&filter[news_category]=#{@slug}"
-    path += "&per_page=#{Paginator::PER_PAGE}&page=#{page}"
-    WpApi.get_json_body(path)
+    WpApi.get_json_body(
+      'news',
+      params: { _embed: 1, 'filter[news_category]': @slug, per_page: Paginator::PER_PAGE, page: page }
+    )
   end
 
   def main_query_headers(page)
@@ -20,7 +21,7 @@ class NewsTypeQueries
   end
 
   def category_title_query(_slug)
-    WpApi.get_json_body("news_categories?slug=#{@slug}")
+    WpApi.get_json_body('news_categories', params: { slug: @slug })
   end
 
   def other_categories_query

--- a/app/models/page_queries.rb
+++ b/app/models/page_queries.rb
@@ -4,19 +4,19 @@ class PageQueries
   end
 
   def header_menu
-    WpApi.get_json_body('menus?slug=header-menu')
+    WpApi.get_json_body('menus', params: { slug: 'header-menu' })
   end
 
   def main_query
-    WpApi.get_json_body("news?slug=#{@slug}")
+    WpApi.get_json_body('news', params: { slug: @slug })
   end
 
   def main_comments_query(id)
-    WpApi.get_json_body("comments?per_page=100&post=#{id}", false)
+    WpApi.get_json_body('comments', params: { per_page: 100, post: id }, use_cache: false)
   end
 
   def self.comment_count_query(id)
-    WpApi.get_json_body("comments?per_page=100&post=#{id}", false)
+    WpApi.get_json_body('comments', params: { per_page: 100, post: id }, use_cache: false)
   end
 
   # def main_comment_headers
@@ -24,7 +24,7 @@ class PageQueries
   # end
 
   def main_comments_query_cache(id)
-    WpApi.get_json_body("comments?per_page=100&post=#{id}", false)
+    WpApi.get_json_body('comments', params: { per_page: 100, post: id }, use_cache: false)
   end
 
   # def main_comment_headers_cache

--- a/app/models/policy_queries.rb
+++ b/app/models/policy_queries.rb
@@ -4,10 +4,10 @@ class PolicyQueries
   end
 
   def policy_query
-    WpApi.get_json_body("policies?slug=#{@slug}")
+    WpApi.get_json_body('policies', params: { slug: @slug })
   end
 
   def topics_related_news
-    WpApi.get_json_body("news?filter[topic_taxonomy]=#{@slug}&per_page=5")
+    WpApi.get_json_body('news', params: { 'filter[topic_taxonomy]': @slug, per_page: 5 })
   end
 end

--- a/app/models/standard_queries.rb
+++ b/app/models/standard_queries.rb
@@ -4,23 +4,23 @@ class StandardQueries
   end
 
   def notifications_query(_slug)
-    WpApi.get_json_body("pages?per_page=100&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { per_page: 100, slug: @slug })
   end
 
   def page_query(_slug)
-    WpApi.get_json_body("pages?per_page=100&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { per_page: 100, slug: @slug })
   end
 
   def main_query(_slug)
-    WpApi.get_json_body("pages?type=standard_index&slug=#{@slug}")
+    WpApi.get_json_body('pages', params: { type: 'standard_index', slug: @slug })
   end
 
   def standard_child_content_query(parent_id)
-    WpApi.get_json_body("pages?type=content&orderby=title&order=asc&per_page=100&parent=#{parent_id}")
+    WpApi.get_json_body('pages', params: { type: 'content', orderby: 'title', order: 'asc', per_page: 100, parent: parent_id })
   end
 
   def standard_child_standard_query(parent_id)
-    WpApi.get_json_body("pages?type=standard_index&orderby=title&order=asc&per_page=100&parent=#{parent_id}")
+    WpApi.get_json_body('pages', params: { type: 'standard_index', orderby: 'title', order: 'asc', per_page: 100, parent: parent_id })
   end
 
   def content_children(arr_a, arr_b)

--- a/app/models/tool_queries.rb
+++ b/app/models/tool_queries.rb
@@ -4,6 +4,6 @@ class ToolQueries
   end
 
   def tools_query
-    WpApi.get_json_body("pages?filter[topic_taxonomy]=#{@slug}&parent_slug=tools&orderby=title&order=asc")
+    WpApi.get_json_body('pages', params: { 'filter[topic_taxonomy]': @slug, parent_slug: 'tools', orderby: 'title', order: 'asc' })
   end
 end

--- a/app/models/topic_child_queries.rb
+++ b/app/models/topic_child_queries.rb
@@ -4,14 +4,14 @@ class TopicChildQueries
   end
 
   def topic_howdoi_query
-    WpApi.get_json_body("howdoi?per_page=100&filter[topic_taxonomy]=#{@slug}&orderby=menu_order&order=desc")
+    WpApi.get_json_body('howdoi', params: { per_page: 100, 'filter[topic_taxonomy]': @slug, orderby: 'menu_order', order: 'desc' })
   end
 
   def topic_policies_query
-    WpApi.get_json_body("policies?per_page=100&filter[topic_taxonomy]=#{@slug}&orderby=menu_order&order=desc")
+    WpApi.get_json_body('policies', params: { per_page: 100, 'filter[topic_taxonomy]': @slug, orderby: 'menu_order', order: 'desc' })
   end
 
   def topic_forms_query
-    WpApi.get_json_body("topics?slug=#{@slug}")
+    WpApi.get_json_body('topics', params: { slug: @slug })
   end
 end

--- a/app/models/topic_queries.rb
+++ b/app/models/topic_queries.rb
@@ -4,7 +4,7 @@ class TopicQueries
   end
 
   def topic_query
-    WpApi.get_json_body("topics?slug=#{@slug}")
+    WpApi.get_json_body('topics', params: { slug: @slug })
   end
 
   def topic_selector
@@ -12,6 +12,6 @@ class TopicQueries
   end
 
   def topics_related_news
-    WpApi.get_json_body("news?filter[topic_taxonomy]=#{@slug}&per_page=5")
+    WpApi.get_json_body('news', params: { 'filter[topic_taxonomy]': @slug, per_page: 5 })
   end
 end

--- a/app/models/topic_theme_queries.rb
+++ b/app/models/topic_theme_queries.rb
@@ -4,6 +4,6 @@ class TopicThemeQueries
   end
 
   def topic_theme_query
-    WpApi.get_json_body("themes?slug=#{@slug}")
+    WpApi.get_json_body('themes', params: { slug: @slug })
   end
 end

--- a/app/models/wp_api.rb
+++ b/app/models/wp_api.rb
@@ -5,7 +5,9 @@ class WpApi
   AUTH_TOKEN = ENV['WP_API_KEY']
 
   class << self
-    def get_json_body(path, use_cache = true)
+    def get_json_body(base_path, params: {}, use_cache: true)
+      path = base_path + '?' + params.to_query
+
       if use_cache
         Rails.cache.fetch("#{path}_body", expires_in: 60) do
           JSON.parse(get_json(path).body)

--- a/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
@@ -47,7 +47,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:10 GMT
 - request:
     method: get
@@ -96,7 +96,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:11 GMT
 - request:
     method: get
@@ -143,7 +143,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:12 GMT
 - request:
     method: get
@@ -190,7 +190,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:12 GMT
 - request:
     method: get
@@ -237,11 +237,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:13 GMT
 - request:
     method: get
-    uri: "<WP_API_URL>popular_pages?_embed&order=asc&orderby=menu_order&per_page=3"
+    uri: "<WP_API_URL>popular_pages?_embed=1&order=asc&orderby=menu_order&per_page=3"
     body:
       encoding: US-ASCII
       string: ''
@@ -284,7 +284,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:14 GMT
 - request:
     method: get
@@ -334,7 +334,7 @@ http_interactions:
         which could be used for the title attribute to get a tooltip?","url":"http:\/\/www.google.com","target":""}},{"image":{"ID":12694,"id":12694,"title":"visualisation3","filename":"visualisation3.png","url":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","alt":"","author":"1","description":"","caption":"","name":"visualisation3","date":"2017-12-06
         10:07:56","modified":"2017-12-06 10:07:56","mime_type":"image\/png","type":"image","icon":"\/wp-includes\/images\/media\/default.png","width":159,"height":159,"sizes":{"thumbnail":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","thumbnail-width":150,"thumbnail-height":150,"medium":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","medium-width":159,"medium-height":159,"medium_large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","medium_large-width":159,"medium_large-height":159,"large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","large-width":159,"large-height":159}},"text":"overall
         engagement score for\r\n<br \/>\r\nDIT ","link":""}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:14 GMT
 - request:
     method: get
@@ -381,7 +381,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:15 GMT
 - request:
     method: post
@@ -455,7 +455,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:15 GMT
 - request:
     method: get
@@ -996,7 +996,7 @@ http_interactions:
         for International Trade \u2013 helping businesses\nexport, driving investment,
         opening up markets and championing free trade","url":"https:\/\/t.co\/KMiwpagkWL","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/KMiwpagkWL","expanded_url":"http:\/\/www.gov.uk\/dit","display_url":"gov.uk\/dit","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":106116,"friends_count":3761,"listed_count":1983,"created_at":"Fri
         Apr 18 10:29:28 +0000 2008","favourites_count":688,"utc_offset":0,"time_zone":"London","geo_enabled":false,"verified":true,"statuses_count":19008,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFFFFF","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/14431752\/1509977613","profile_link_color":"CF102D","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"E6F6F9","profile_text_color":"CC3366","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null,"translator_type":"none"},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":55,"favorite_count":48,"favorited":false,"retweeted":false,"possibly_sensitive":false,"lang":"en"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:16 GMT
 - request:
     method: get
@@ -1043,7 +1043,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:16 GMT
 - request:
     method: get
@@ -1090,6 +1090,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:17 GMT
 recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
@@ -47,7 +47,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:17 GMT
 - request:
     method: get
@@ -96,7 +96,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:18 GMT
 - request:
     method: get
@@ -143,7 +143,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:18 GMT
 - request:
     method: get
@@ -190,7 +190,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:19 GMT
 - request:
     method: get
@@ -237,11 +237,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:19 GMT
 - request:
     method: get
-    uri: "<WP_API_URL>popular_pages?_embed&order=asc&orderby=menu_order&per_page=3"
+    uri: "<WP_API_URL>popular_pages?_embed=1&order=asc&orderby=menu_order&per_page=3"
     body:
       encoding: US-ASCII
       string: ''
@@ -284,7 +284,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:20 GMT
 - request:
     method: get
@@ -334,7 +334,7 @@ http_interactions:
         which could be used for the title attribute to get a tooltip?","url":"http:\/\/www.google.com","target":""}},{"image":{"ID":12694,"id":12694,"title":"visualisation3","filename":"visualisation3.png","url":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","alt":"","author":"1","description":"","caption":"","name":"visualisation3","date":"2017-12-06
         10:07:56","modified":"2017-12-06 10:07:56","mime_type":"image\/png","type":"image","icon":"\/wp-includes\/images\/media\/default.png","width":159,"height":159,"sizes":{"thumbnail":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","thumbnail-width":150,"thumbnail-height":150,"medium":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","medium-width":159,"medium-height":159,"medium_large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","medium_large-width":159,"medium_large-height":159,"large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","large-width":159,"large-height":159}},"text":"overall
         engagement score for\r\n<br \/>\r\nDIT ","link":""}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:20 GMT
 - request:
     method: get
@@ -381,7 +381,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -922,7 +922,7 @@ http_interactions:
         for International Trade \u2013 helping businesses\nexport, driving investment,
         opening up markets and championing free trade","url":"https:\/\/t.co\/KMiwpagkWL","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/KMiwpagkWL","expanded_url":"http:\/\/www.gov.uk\/dit","display_url":"gov.uk\/dit","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":106121,"friends_count":3761,"listed_count":1983,"created_at":"Fri
         Apr 18 10:29:28 +0000 2008","favourites_count":688,"utc_offset":0,"time_zone":"London","geo_enabled":false,"verified":true,"statuses_count":19008,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFFFFF","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/14431752\/1509977613","profile_link_color":"CF102D","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"E6F6F9","profile_text_color":"CC3366","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null,"translator_type":"none"},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":55,"favorite_count":48,"favorited":false,"retweeted":false,"possibly_sensitive":false,"lang":"en"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -969,7 +969,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -1016,7 +1016,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:22 GMT
 - request:
     method: get
@@ -1065,11 +1065,11 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:22 GMT
 - request:
     method: get
-    uri: "<WP_API_URL>news?_embed&page=1&per_page=10"
+    uri: "<WP_API_URL>news?_embed=1&page=1&per_page=10"
     body:
       encoding: US-ASCII
       string: ''
@@ -1112,7 +1112,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:23 GMT
 - request:
     method: get
@@ -1159,7 +1159,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:24 GMT
 - request:
     method: get
@@ -1206,7 +1206,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:25 GMT
 - request:
     method: get
@@ -1253,7 +1253,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:25 GMT
 - request:
     method: get
@@ -1300,7 +1300,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1349,7 +1349,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1396,7 +1396,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1445,7 +1445,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1492,7 +1492,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
@@ -1541,7 +1541,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
@@ -1588,7 +1588,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
@@ -1637,7 +1637,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1684,7 +1684,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1733,7 +1733,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1780,7 +1780,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1829,7 +1829,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -1876,7 +1876,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -1925,7 +1925,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -1972,7 +1972,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -2019,7 +2019,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:30 GMT
 - request:
     method: get
@@ -2066,6 +2066,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:30 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
WpApi should be using the Rails standard library to build up a query
string to send to Wordpress, rather than receiving arbitrary path
strings (which `URI` refuses to deal with if they contain non-ASCII
characters, leading to an error in the HTTP library).