### PR TITLE
Use `large` images on homepage again (for now)

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -46,7 +46,7 @@
             .news-item
               .news-item-image
                 - if image_exists?(p)
-                  = medium_image_tag(p)
+                  = large_image_tag(p)
 
               .news-item-text
                 .post-meta


### PR DESCRIPTION
Wordpress doesn't actually generate medium images - they have been
disabled for some reason. Instead, in the field for medium image,
it returns a full size image, which is even worse than large...

This reverts the image size for now, until we can get Wordpress
fixed.