### PR TITLE
Use Typhoeus instead of HTTParty as HTTP library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'json'
 
 gem 'govuk_elements_rails'
 gem 'govuk_template'
-gem 'httparty'
+gem 'typhoeus'
 gem 'omniauth-oauth2'
 
 gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     equalizer (0.0.11)
     erubi (1.7.1)
     erubis (2.7.0)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     execjs (2.7.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
@@ -123,8 +125,6 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
-    httparty (0.15.6)
-      multi_xml (>= 0.5.2)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
@@ -304,6 +304,8 @@ GEM
       memoizable (~> 0.4.2)
       naught (~> 1.1)
       simple_oauth (~> 0.3.1)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -347,7 +349,6 @@ DEPENDENCIES
   govuk_template
   haml-rails (~> 1.0)
   health_check
-  httparty
   jbuilder (~> 2.5)
   json
   launchy
@@ -367,6 +368,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   twitter
+  typhoeus
   uglifier (>= 1.3.0)
   vcr
   web-console (>= 3.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
-require 'httparty'
-
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :ensure_sso_user

--- a/app/models/people_finder_profile.rb
+++ b/app/models/people_finder_profile.rb
@@ -1,5 +1,3 @@
-require 'httparty'
-
 class PeopleFinderProfile
   BASE_URL = ENV['PEOPLEFINDER_URL']
   AUTH_TOKEN = ENV['PEOPLEFINDER_AUTH_TOKEN']
@@ -26,7 +24,7 @@ class PeopleFinderProfile
     private
 
     def retrieve_user
-      response = HTTParty.get(
+      response = Typhoeus.get(
         "#{URI.join(BASE_URL, '/api/people')}?email=#{@email}",
         headers: {
           'Authorization' => "Token token=#{AUTH_TOKEN}"

--- a/app/models/wp_api.rb
+++ b/app/models/wp_api.rb
@@ -1,5 +1,4 @@
 class WpApi
-  require 'httparty'
   BASE_URI = ENV['WP_API_URL']
   BASE_CUSTOM_URI = ENV['WP_API_CUSTOM']
   AUTH_TOKEN = ENV['WP_API_KEY']
@@ -38,7 +37,7 @@ class WpApi
     end
 
     def get_json(path)
-      HTTParty.get(
+      Typhoeus.get(
         URI.join(BASE_URI, path).to_s,
         headers: {
           'Authorization' => "Basic #{AUTH_TOKEN}"
@@ -47,7 +46,7 @@ class WpApi
     end
 
     def get_custom_json(path)
-      HTTParty.get(
+      Typhoeus.get(
         URI.join(BASE_CUSTOM_URI, path).to_s,
         headers: {
           'Authorization' => "Basic #{AUTH_TOKEN}"
@@ -56,7 +55,7 @@ class WpApi
     end
 
     def post_comment_json(json)
-      HTTParty.post(
+      Typhoeus.post(
         URI.join(BASE_URI, 'comments').to_s,
         body: json,
         headers: { 'Authorization' => "Basic #{AUTH_TOKEN}" }
@@ -78,7 +77,7 @@ class WpApi
     def search_json_request(base_path, params: {})
       path = base_path + '?' + params.to_query
 
-      HTTParty.get(
+      Typhoeus.get(
         URI.join(BASE_CUSTOM_URI, path).to_s,
         headers: {
           'Authorization' => "Basic #{AUTH_TOKEN}"

--- a/app/services/custom_health_check.rb
+++ b/app/services/custom_health_check.rb
@@ -1,6 +1,4 @@
 class CustomHealthCheck
-  require 'httparty'
-
   def self.perform_check
     health_check = CustomHealthCheck.new
     health_check.response
@@ -19,7 +17,7 @@ class CustomHealthCheck
   private
 
   def check_peoplefinder_api
-    response = HTTParty.get(
+    response = Typhoeus.get(
       "#{URI.join(ENV['PEOPLEFINDER_URL'], '/api/people')}?email=something-random",
       headers: {
         'Authorization' => "Token token=#{ENV['PEOPLEFINDER_AUTH_TOKEN']}"
@@ -31,7 +29,7 @@ class CustomHealthCheck
   end
 
   def check_wordpress_api
-    response = HTTParty.get(
+    response = Typhoeus.get(
       ENV['WP_API_URL'],
       headers: {
         'Authorization' => "Basic #{ENV['WP_API_KEY']}"

--- a/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
@@ -459,7 +459,7 @@ http_interactions:
   recorded_at: Thu, 07 Dec 2017 10:11:15 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/user_timeline.json?count=100&exclude_replies=true&include_rts=false&screen_name=tradegovuk
+    uri: https://api.twitter.com/1.1/statuses/user_timeline.json?count=25&exclude_replies=true&include_rts=false&screen_name=tradegovuk
     body:
       encoding: US-ASCII
       string: ''

--- a/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
@@ -385,7 +385,7 @@ http_interactions:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
-    uri: https://api.twitter.com/1.1/statuses/user_timeline.json?count=100&exclude_replies=true&include_rts=false&screen_name=tradegovuk
+    uri: https://api.twitter.com/1.1/statuses/user_timeline.json?count=25&exclude_replies=true&include_rts=false&screen_name=tradegovuk
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/models/people_finder_profile_spec.rb
+++ b/spec/models/people_finder_profile_spec.rb
@@ -10,7 +10,7 @@ describe PeopleFinderProfile do
       before do
         response = double(:response, body: people_finder_hash, success?: true)
 
-        allow(HTTParty)
+        allow(Typhoeus)
           .to receive(:get)
           .and_return(response)
       end
@@ -78,7 +78,7 @@ describe PeopleFinderProfile do
       let(:response) { double('Response', success?: false, body: 'Internal server error') }
 
       before do
-        allow(HTTParty)
+        allow(Typhoeus)
           .to receive(:get)
           .and_return(response)
       end


### PR DESCRIPTION
Typhoeus is based on `libcurl` and allows us to work around issues with
invalid responses from Wordpress because it is more forgiving of
malformed HTTP responses (in particular the missing `Content-Length`
header we've been experiencing).

It's a drop in replacement for now, but will also allow us to perform
parallel requests and use persistent connections in the future, in order
to improve performance on some of the slowest parts of Workspace.