### PR TITLE
Fix notification banner not showing on homepage

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,5 +4,9 @@ class HomeController < ApplicationController
     @posts = @api_call.main_query
     @howdois = @api_call.howdois
     @popular_posts = @api_call.popular_posts
+
+    # TODO: This is awful but added like this to keep it consistent with other
+    #   controllers for now. Needs refactoring.
+    @global_notification = @posts.first if @posts.first.is_a?(Hash)
   end
 end


### PR DESCRIPTION
This is implemented in the most awful way imaginable, but this commit
replicates the behaviour of the way it's done across the rest of the
application for the sake of consistency.

The notification banner is returned as an attribute on *every single
content item type* in Wordpress. Every controller fetches the first
item of content and chucks it into `@global_notification`, where the
notification partial in the application layout picks up on it. The
homepage wasn't doing that. Now it does.