### PR TITLE
Increase number of topics displayed per theme

### DIFF
--- a/app/models/accordion_queries.rb
+++ b/app/models/accordion_queries.rb
@@ -16,6 +16,6 @@ class AccordionQueries
   end
 
   def self.accordion_topic_query(theme_slug)
-    WpApi.get_json_body('topics', params: { 'filter[theme_taxonomy]': theme_slug, orderby: 'title', order: 'asc' })
+    WpApi.get_json_body('topics', params: { 'filter[theme_taxonomy]': theme_slug, orderby: 'title', order: 'asc', per_page: 50 })
   end
 end


### PR DESCRIPTION
On the "Working at DIT" page, the individual themes only show up to a
maximum of 10 topics because of the default Wordpress fetch limit.

Never mind that these should not be one HTTP request per theme...