### PR TITLE
Show icon and file size for document links

### DIFF
--- a/app/assets/stylesheets/util/_lists.scss
+++ b/app/assets/stylesheets/util/_lists.scss
@@ -28,4 +28,9 @@ ol.list-style-a {
 	.related-content & {
 		margin-bottom: 20px;
 	}
+
+  .icon {
+    vertical-align: middle;
+    margin-right: 4px;
+  }
 }

--- a/app/views/widgets/_content_partial.html.haml
+++ b/app/views/widgets/_content_partial.html.haml
@@ -55,5 +55,11 @@
             - content["acf"]["documents"].each do |docs|
               %ul.list-style-a
                 %li
-                  = link_to( docs["title"], docs["file"]["url"])
+                  %i.icon.icon-file-download
+                    %span.visually-hidden
+                      Download
+                  = link_to(docs["file"]["url"]) do
+                    = docs["title"]
+                    - if docs['file']['filesize']
+                      = "(#{number_to_human_size(docs['file']['filesize'])})"
 = render partial: "widgets/related_news_partial"


### PR DESCRIPTION
Currently there is nothing to differentiate links to downloadable
documents in the "Documents" section from random hyperlinks.

As an MVP, this adds the GDS "file download" icon to every link in the
documents section, as well as the file size coming through from
Wordpress.