### PR TITLE
Amend margin for download link icons

### DIFF
--- a/app/assets/stylesheets/util/_lists.scss
+++ b/app/assets/stylesheets/util/_lists.scss
@@ -31,6 +31,6 @@ ol.list-style-a {
 
   .icon {
     vertical-align: middle;
-    margin-right: 4px;
+    margin: 0 4px 4px 0;
   }
 }


### PR DESCRIPTION
These were a bit too close together and should be spaced further apart.