### PR TITLE
Add file expiry warning to error report form

### DIFF
--- a/app/assets/stylesheets/components/_zendesk.scss
+++ b/app/assets/stylesheets/components/_zendesk.scss
@@ -107,6 +107,10 @@
 		margin: 5px 0;
 	}
 
+  .notice-link-expiry {
+    margin: 15px 0;
+  }
+
 	#content {
 		outline: none;
 		padding-bottom: 30px;

--- a/app/views/widgets/_zendesk_footer.html.haml
+++ b/app/views/widgets/_zendesk_footer.html.haml
@@ -2,6 +2,12 @@
   %a{:href => '#feedback', :id => 'feedbackToggle'}
     Is there anything wrong with this page?
   = form_tag('/report_problem', method: :post, class: 'new_problem_report', id: 'new_problem_report') do
+    .notice.notice-link-expiry
+      %i.icon.icon-important
+        %span.visually-hidden Notice
+      %strong.bold-xsmall
+        Download links on this page expire after 15 minutes for security reasons. If you clicked on a link and received an error message,
+        please refresh the page in your browser and try again. If that hasn't fixed your issue, let us know.
     .form-group
       = label_tag('problem_report_goal', 'What were you trying to do?', {:class => 'form-label'})
       = text_area_tag('problem_report_goal', '', {:class => 'form-control', :id => 'problem_report_goal'})


### PR DESCRIPTION
One of the most common error reports received by the Digital Workspace
team is that the links on the page are not working. This is due to the
file links to S3 coming through from Wordpress as signed URLs expiring
after 15 minutes - if a users has a Digital Workspace page open in the
background for longer than that, all the links end up leading to a AWS
error page.

We cannot (easily) fix the underlying cause due to the way the Wordpress
media library offloading plugin works, and the myriad ways in which the
URLs come back from the Wordpress API, so this adds a message to the
error reporting form suggesting that if this is what the user is writing
to complain about, they should try refreshing their browser first.