### PR TITLE
Adapt header link highlighting to new menu order

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -260,7 +260,7 @@
 	#global-header {
 		.header-proposition {
 			#proposition-links {
-				li:nth-child(2) {
+				li:nth-child(3) {
 					a {
 						color: $brand_color_a;
 					}
@@ -274,20 +274,6 @@
 	#global-header {
 		.header-proposition {
 			#proposition-links {
-				li:nth-child(3) {
-					a {
-						color: $brand_color_a;
-					}
-				}
-			}
-		}
-	}
-}
-
-.section-tools {
-	#global-header {
-		.header-proposition {
-			#proposition-links {
 				li:nth-child(4) {
 					a {
 						color: $brand_color_a;
@@ -298,7 +284,7 @@
 	}
 }
 
-.section-datahub {
+.section-tools {
 	#global-header {
 		.header-proposition {
 			#proposition-links {


### PR DESCRIPTION
The order of links in the header menu has changed, and since active
menu items are highlighted by position, they are now broken. This fixes
the order of items.

The Data Hub section is pointless because it's not a section - it will
still highlight "working at DIT".