### PR TITLE
Use SSO user_id instead of email to fetch PF profile

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,13 @@ class ApplicationController < ActionController::Base
   before_action :load_people_finder_profile
 
   def current_user
-    AuthUser.new(email: session[:auth_email])
+    AuthUser.new(ditsso_user_id: session[:ditsso_user_id])
   end
 
   private
 
   def ensure_sso_user
-    session[:auth_email] || redirect_to("/auth/ditsso_internal?origin=#{ERB::Util.url_encode(request.fullpath)}")
+    session[:ditsso_user_id] || redirect_to("/auth/ditsso_internal?origin=#{ERB::Util.url_encode(request.fullpath)}")
   end
 
   def load_people_finder_profile

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,8 @@ class SessionsController < ApplicationController
   skip_before_action :ensure_sso_user, only: [:create]
 
   def create
-    session[:auth_email] =
-      AuthUser.from_omniauth_hash(request.env['omniauth.auth']).email
+    session[:ditsso_user_id] =
+      AuthUser.from_omniauth_hash(request.env['omniauth.auth']).ditsso_user_id
     redirect_to(request.env['omniauth.origin'] || '/')
   end
 end

--- a/app/models/auth_user.rb
+++ b/app/models/auth_user.rb
@@ -1,13 +1,11 @@
 class AuthUser
   include ActiveModel::Model
 
-  attr_accessor(
-    :email
-  )
+  attr_accessor(:email, :ditsso_user_id)
 
   class << self
     def from_omniauth_hash(auth_hash = {})
-      AuthUser.new(email: auth_hash[:info] ? auth_hash[:info][:email] : nil)
+      AuthUser.new(ditsso_user_id: auth_hash['uid'])
     end
   end
 end

--- a/app/models/people_finder_profile.rb
+++ b/app/models/people_finder_profile.rb
@@ -3,6 +3,7 @@ class PeopleFinderProfile
   AUTH_TOKEN = ENV['PEOPLEFINDER_AUTH_TOKEN']
 
   attr_accessor(
+    :ditsso_user_id,
     :email,
     :name,
     :given_name,
@@ -19,7 +20,7 @@ class PeopleFinderProfile
 
   class << self
     def from_api(user)
-      @email = user.is_a?(AuthUser) ? user.email : user.to_s
+      @ditsso_user_id = user.is_a?(AuthUser) ? user.ditsso_user_id : user.to_s
       retrieve_user
       assign_user
       @profile
@@ -29,7 +30,7 @@ class PeopleFinderProfile
 
     def retrieve_user
       response = Typhoeus.get(
-        "#{URI.join(BASE_URL, '/api/people')}?email=#{@email}",
+        "#{URI.join(BASE_URL, '/api/people')}?ditsso_user_id=#{@ditsso_user_id}",
         headers: {
           'Authorization' => "Token token=#{AUTH_TOKEN}"
         }
@@ -42,7 +43,7 @@ class PeopleFinderProfile
 
     def assign_user
       @profile = PeopleFinderProfile.new
-      @profile.email = @email
+      @profile.email = @attributes['email']
       @profile.name = @attributes['name']
       @profile.given_name = @attributes['given-name']
       @profile.surname = @attributes['surname']

--- a/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_landing_page/in_general.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email="
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id="
     body:
       encoding: US-ASCII
       string: ''
@@ -47,11 +47,11 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:10 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=alice@example.com"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=deadbeef"
     body:
       encoding: US-ASCII
       string: ''
@@ -96,7 +96,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:11 GMT
 - request:
     method: get
@@ -143,7 +143,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:12 GMT
 - request:
     method: get
@@ -190,7 +190,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:12 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:13 GMT
 - request:
     method: get
@@ -284,7 +284,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:14 GMT
 - request:
     method: get
@@ -334,7 +334,7 @@ http_interactions:
         which could be used for the title attribute to get a tooltip?","url":"http:\/\/www.google.com","target":""}},{"image":{"ID":12694,"id":12694,"title":"visualisation3","filename":"visualisation3.png","url":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","alt":"","author":"1","description":"","caption":"","name":"visualisation3","date":"2017-12-06
         10:07:56","modified":"2017-12-06 10:07:56","mime_type":"image\/png","type":"image","icon":"\/wp-includes\/images\/media\/default.png","width":159,"height":159,"sizes":{"thumbnail":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","thumbnail-width":150,"thumbnail-height":150,"medium":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","medium-width":159,"medium-height":159,"medium_large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","medium_large-width":159,"medium_large-height":159,"large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101114Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=98efa787ca89ab3b0eb6bd728e2e321ef7ea75ea0ba4c95a371e5a23716091bf","large-width":159,"large-height":159}},"text":"overall
         engagement score for\r\n<br \/>\r\nDIT ","link":""}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:14 GMT
 - request:
     method: get
@@ -381,7 +381,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:15 GMT
 - request:
     method: post
@@ -455,7 +455,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:15 GMT
 - request:
     method: get
@@ -996,7 +996,7 @@ http_interactions:
         for International Trade \u2013 helping businesses\nexport, driving investment,
         opening up markets and championing free trade","url":"https:\/\/t.co\/KMiwpagkWL","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/KMiwpagkWL","expanded_url":"http:\/\/www.gov.uk\/dit","display_url":"gov.uk\/dit","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":106116,"friends_count":3761,"listed_count":1983,"created_at":"Fri
         Apr 18 10:29:28 +0000 2008","favourites_count":688,"utc_offset":0,"time_zone":"London","geo_enabled":false,"verified":true,"statuses_count":19008,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFFFFF","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/14431752\/1509977613","profile_link_color":"CF102D","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"E6F6F9","profile_text_color":"CC3366","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null,"translator_type":"none"},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":55,"favorite_count":48,"favorited":false,"retweeted":false,"possibly_sensitive":false,"lang":"en"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:16 GMT
 - request:
     method: get
@@ -1043,7 +1043,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:16 GMT
 - request:
     method: get
@@ -1090,7 +1090,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:17 GMT
 - request:
     method: get
@@ -1145,6 +1145,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Tue, 19 Mar 2019 13:56:52 GMT
 recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
+++ b/fixtures/vcr_cassettes/visit_the_news_pages/in_general.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email="
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id="
     body:
       encoding: US-ASCII
       string: ''
@@ -47,11 +47,11 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:17 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=alice@example.com"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=deadbeef"
     body:
       encoding: US-ASCII
       string: ''
@@ -96,7 +96,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:18 GMT
 - request:
     method: get
@@ -143,7 +143,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:18 GMT
 - request:
     method: get
@@ -190,7 +190,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:19 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:19 GMT
 - request:
     method: get
@@ -284,7 +284,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:20 GMT
 - request:
     method: get
@@ -334,7 +334,7 @@ http_interactions:
         which could be used for the title attribute to get a tooltip?","url":"http:\/\/www.google.com","target":""}},{"image":{"ID":12694,"id":12694,"title":"visualisation3","filename":"visualisation3.png","url":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","alt":"","author":"1","description":"","caption":"","name":"visualisation3","date":"2017-12-06
         10:07:56","modified":"2017-12-06 10:07:56","mime_type":"image\/png","type":"image","icon":"\/wp-includes\/images\/media\/default.png","width":159,"height":159,"sizes":{"thumbnail":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","thumbnail-width":150,"thumbnail-height":150,"medium":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","medium-width":159,"medium-height":159,"medium_large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","medium_large-width":159,"medium_large-height":159,"large":"https:\/\/dit-workspace-staging.s3-eu-west-1.amazonaws.com\/wp-content\/uploads\/2017\/12\/06100756\/visualisation3.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIBGJDZ6XYFQH4R6A%2F20171207%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20171207T101120Z&X-Amz-SignedHeaders=Host&X-Amz-Expires=900&X-Amz-Signature=c4b64d6666e62d4c9a1fc45758192fcb558f78a4945ef65d6ce76c3fd9026933","large-width":159,"large-height":159}},"text":"overall
         engagement score for\r\n<br \/>\r\nDIT ","link":""}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:20 GMT
 - request:
     method: get
@@ -381,7 +381,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -922,7 +922,7 @@ http_interactions:
         for International Trade \u2013 helping businesses\nexport, driving investment,
         opening up markets and championing free trade","url":"https:\/\/t.co\/KMiwpagkWL","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/KMiwpagkWL","expanded_url":"http:\/\/www.gov.uk\/dit","display_url":"gov.uk\/dit","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":106121,"friends_count":3761,"listed_count":1983,"created_at":"Fri
         Apr 18 10:29:28 +0000 2008","favourites_count":688,"utc_offset":0,"time_zone":"London","geo_enabled":false,"verified":true,"statuses_count":19008,"lang":"en","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFFFFF","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/700441044\/4174d13512e47beb737fe6c0f8a92433.jpeg","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/929987679701389312\/Pk9RsQfU_normal.jpg","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/14431752\/1509977613","profile_link_color":"CF102D","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"E6F6F9","profile_text_color":"CC3366","profile_use_background_image":false,"has_extended_profile":false,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null,"translator_type":"none"},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":55,"favorite_count":48,"favorited":false,"retweeted":false,"possibly_sensitive":false,"lang":"en"}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -969,7 +969,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:21 GMT
 - request:
     method: get
@@ -1016,11 +1016,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:22 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=alice@example.com"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=deadbeef"
     body:
       encoding: US-ASCII
       string: ''
@@ -1065,7 +1065,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:22 GMT
 - request:
     method: get
@@ -1112,7 +1112,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:23 GMT
 - request:
     method: get
@@ -1159,7 +1159,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:24 GMT
 - request:
     method: get
@@ -1206,7 +1206,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:25 GMT
 - request:
     method: get
@@ -1253,7 +1253,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:25 GMT
 - request:
     method: get
@@ -1300,11 +1300,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=dennis.flood@rainmaker.solutions"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=deadbeef"
     body:
       encoding: US-ASCII
       string: ''
@@ -1349,7 +1349,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1396,11 +1396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=<removed>"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=<removed>"
     body:
       encoding: US-ASCII
       string: ''
@@ -1445,7 +1445,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:26 GMT
 - request:
     method: get
@@ -1492,11 +1492,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=<removed>"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=<removed>"
     body:
       encoding: US-ASCII
       string: ''
@@ -1541,7 +1541,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
@@ -1588,11 +1588,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:27 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=<removed>"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=<removed>"
     body:
       encoding: US-ASCII
       string: ''
@@ -1637,7 +1637,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1684,11 +1684,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=<removed>"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=<removed>"
     body:
       encoding: US-ASCII
       string: ''
@@ -1733,7 +1733,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
@@ -1780,11 +1780,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:28 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=<removed>"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=<removed>"
     body:
       encoding: US-ASCII
       string: ''
@@ -1829,7 +1829,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -1876,11 +1876,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
-    uri: "<PEOPLEFINDER_URL>/api/people?email=dennis.flood@rainmaker.solutions"
+    uri: "<PEOPLEFINDER_URL>/api/people?ditsso_user_id=dennis.flood@rainmaker.solutions"
     body:
       encoding: US-ASCII
       string: ''
@@ -1925,7 +1925,7 @@ http_interactions:
       string: 'HTTP Token: Access denied.
 
 '
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -1972,7 +1972,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:29 GMT
 - request:
     method: get
@@ -2019,7 +2019,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:30 GMT
 - request:
     method: get
@@ -2066,7 +2066,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Thu, 07 Dec 2017 10:11:30 GMT
 - request:
     method: get
@@ -2121,7 +2121,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[]"
-    http_version: 
+    http_version:
   recorded_at: Tue, 19 Mar 2019 13:56:04 GMT
 - request:
     method: post
@@ -2195,6 +2195,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{}"
-    http_version: 
+    http_version:
   recorded_at: Tue, 19 Mar 2019 13:56:04 GMT
 recorded_with: VCR 3.0.3

--- a/lib/ditsso_internal.rb
+++ b/lib/ditsso_internal.rb
@@ -11,14 +11,15 @@ module OmniAuth
              token_url: "#{SSO_PROVIDER}/o/token/"
 
       uid do
-        raw_info['id']
+        raw_info['user_id']
       end
 
       info do
         {
           first_name: raw_info['first_name'],
           last_name: raw_info['last_name'],
-          email: raw_info['email'].downcase
+          email: raw_info['email'].downcase,
+          ditsso_user_id: raw_info['user_id']
         }
       end
 

--- a/spec/models/auth_user_spec.rb
+++ b/spec/models/auth_user_spec.rb
@@ -8,7 +8,7 @@ describe AuthUser do
       let(:omniauth_hash) { valid_omnniauth_user }
 
       it 'sets the email address' do
-        expect(subject.email).to eq('alice@example.com')
+        expect(subject.ditsso_user_id).to eq('deadbeef')
       end
     end
 
@@ -16,7 +16,7 @@ describe AuthUser do
       let(:omniauth_hash) { { name: 'bob' } }
 
       it 'fails gracefully' do
-        expect(subject.email).to be_nil
+        expect(subject.ditsso_user_id).to be_nil
       end
     end
   end

--- a/spec/support/helpers/omniauth_helper.rb
+++ b/spec/support/helpers/omniauth_helper.rb
@@ -5,7 +5,8 @@ def valid_omnniauth_user
       email: 'alice@example.com',
       first_name: 'Alice',
       last_name: 'Arnold'
-    }
+    },
+    uid: 'deadbeef'
   )
 end
 


### PR DESCRIPTION
We currently fetch user profiles from People Finder based on a user's
Omniauth email address - this should use the unique `user_id` instead.

NOTE: Deploying this will sign out all currently signed in users.