### PR TITLE
Use WP-provided author name instead of name from PF

### DIFF
--- a/app/views/archive/index.html.haml
+++ b/app/views/archive/index.html.haml
@@ -66,10 +66,9 @@
                 = link_to(p["title"]["rendered"].html_safe, link_news_top + p["slug"])
               .news-item-text
                 .post-meta
-                  - profile = PeopleFinderProfile.from_api(p["author_email"])
                   - author_name = p["acf"]["author_name"].present? ? p["acf"]["author_name"] : p["author_name"]
                   = succeed ', ' do
-                    = profile.name || author_name
+                    = author_name
                   = get_date(p["date"])
 
                   - cat_length = p["news_categories"].length - 1

--- a/app/views/archive/news_type.html.haml
+++ b/app/views/archive/news_type.html.haml
@@ -68,10 +68,9 @@
               = link_to(p["title"]["rendered"].html_safe, link_news_top + p["slug"])
             .news-item-text
               .post-meta
-                - profile = PeopleFinderProfile.from_api(p["author_email"])
                 - author_name = p["acf"]["author_name"].present? ? p["acf"]["author_name"] : p["author_name"]
                 = succeed ', ' do
-                  = profile.name || author_name
+                  = author_name
 
                 = get_date(p["date"])
                 - cat_length = p["news_categories"].length - 1

--- a/app/views/single/news.html.haml
+++ b/app/views/single/news.html.haml
@@ -50,10 +50,9 @@
               %hr{:class => 'rule-small'}
               = @page_title = p["title"]["rendered"].html_safe
             .post-meta
-              - profile = PeopleFinderProfile.from_api(p["author_email"])
               - author_name = p["acf"]["author_name"].present? ? p["acf"]["author_name"] : p["author_name"]
               = succeed ', ' do
-                = profile.name || author_name
+                = author_name
               = get_date(p["date"])
               - cat_length = p["news_categories"].length - 1
               - p["news_categories"].each_with_index do |cat, i|


### PR DESCRIPTION
News articles currently fetch the names of authors from People Finder,
which is completely pointless because they come through from Wordpress
anyway. Also, this no longer works now because People Finder profiles
need to be fetched by SSO user ID.

This changes all the relevant templates to use the author name straight
from Wordpress instead.