### PR TITLE
Fix People Finder URL in header

### DIFF
--- a/app/models/people_finder_profile.rb
+++ b/app/models/people_finder_profile.rb
@@ -1,5 +1,6 @@
 class PeopleFinderProfile
   BASE_URL = ENV['PEOPLEFINDER_API_URL']
+  BASE_END_USER_URL = ENV['PEOPLEFINDER_URL']
   AUTH_TOKEN = ENV['PEOPLEFINDER_AUTH_TOKEN']
 
   attr_accessor(
@@ -54,7 +55,7 @@ class PeopleFinderProfile
     end
 
     def people_finder_my_profile_url
-      URI.join(PeopleFinderProfile::BASE_URL, 'my/profile').to_s
+      URI.join(PeopleFinderProfile::BASE_END_USER_URL, 'my/profile').to_s
     end
   end
 end


### PR DESCRIPTION
The "my profile" link in the header should use the end-user facing
People Finder URL rather than the internal API URL.