### PR TITLE
Improve error reporting for users without PF profile

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :load_people_finder_profile
 
   def current_user
-    AuthUser.new(ditsso_user_id: session[:ditsso_user_id])
+    AuthUser.new(ditsso_user_id: session[:ditsso_user_id], email: session[:email])
   end
 
   private

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -25,7 +25,8 @@ class ReportController < ApplicationController
 
   def requester
     @requester ||= @people_finder_profile
-    @requester.name ||= 'Unknown'
+    @requester.name ||= 'User without profile'
+    @requester.email ||= current_user.email
     @requester
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,10 @@ class SessionsController < ApplicationController
   skip_before_action :ensure_sso_user, only: [:create]
 
   def create
-    session[:ditsso_user_id] =
-      AuthUser.from_omniauth_hash(request.env['omniauth.auth']).ditsso_user_id
+    auth_user = AuthUser.from_omniauth_hash(request.env['omniauth.auth'])
+    session[:ditsso_user_id] = auth_user.ditsso_user_id
+    session[:email] = auth_user.email
+
     redirect_to(request.env['omniauth.origin'] || '/')
   end
 end

--- a/app/models/auth_user.rb
+++ b/app/models/auth_user.rb
@@ -5,7 +5,7 @@ class AuthUser
 
   class << self
     def from_omniauth_hash(auth_hash = {})
-      AuthUser.new(ditsso_user_id: auth_hash['uid'])
+      AuthUser.new(ditsso_user_id: auth_hash['uid'], email: auth_hash.dig('info', 'email'))
     end
   end
 end


### PR DESCRIPTION
If a user does not have a People Finder profile, their error reports
will come through as "Unknown user" without any ability to contact them.

This re-adds `email` as a property of `AuthUser`, and sends through the
user's SSO email in case they do not have a People Finder profile email
we can obtain.