### PR TITLE
Add GOV.UK news from RSS feed to homepage

### DIFF
--- a/app/assets/stylesheets/pages/home/_homepage.scss
+++ b/app/assets/stylesheets/pages/home/_homepage.scss
@@ -196,6 +196,14 @@
 }
 
 // ------------------------------------
+// homepage GOV.UK news
+
+.govuknews-date {
+	color: #6f777b;
+	display: block;
+}
+
+// ------------------------------------
 // homepage graph summaries
 
 .graph-summary {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,7 @@ class HomeController < ApplicationController
     @posts = @api_call.main_query
     @howdois = @api_call.howdois
     @popular_posts = @api_call.popular_posts
+    @govuk_news = @api_call.govuk_news
 
     @quick_links_menu_title = @api_call.quick_links_menu_title
     @quick_links_menu_content = @api_call.quick_links_menu_content

--- a/app/models/govuk_feed.rb
+++ b/app/models/govuk_feed.rb
@@ -1,0 +1,20 @@
+require 'rss'
+
+GovukLink = Struct.new(:title, :url, :summary, :updated_at)
+
+class GovukFeed
+  FEED_URL = 'https://www.gov.uk/search/news-and-communications.atom?organisations%5B%5D=department-for-international-trade'
+
+  def news_feed(count = 5)
+    Rails.cache.fetch('govuk_rss_feed', expires_in: 30.minutes) do
+      URI.parse(FEED_URL).open do |rss|
+        feed = RSS::Parser.parse(rss)
+        feed.items.first(count).map do |item|
+          GovukLink.new(item.title.content, item.link.href, item.summary.content, item.updated.content)
+        end
+      end
+    end
+  rescue
+    []
+  end
+end

--- a/app/models/home_page_queries.rb
+++ b/app/models/home_page_queries.rb
@@ -46,6 +46,10 @@ class HomePageQueries
     WpApi.get_headers('comments')
   end
 
+  def govuk_news
+    GovukFeed.new.news_feed(6)
+  end
+
   def quick_links_menu
     @quick_links_menu ||= WpApi.get_json_body('menus', params: { slug: 'homepage-quick-links-menu' })
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -122,6 +122,35 @@
       </div>
     </div>
 
+        <hr class="rule-large" id="popular"/>
+
+    <div class="grid-row">
+      <div class="column-full">
+        <h2 class="heading-medium">
+          DIT news from GOV.UK
+        </h2>
+      </div>
+    </div>
+
+    <div class="grid-row">
+      <% if @govuk_news.present? %>
+        <% @govuk_news.in_groups(2, false) do |group| %>
+          <div class="column-half">
+            <ul class="list-style-a govuknews">
+              <% group.each do |item| %>
+                <li>
+                  <%= link_to(item.title, item.url) %>
+                  <date class="govuknews-date">
+                    <%= item.updated_at.strftime('%d %B %Y') %>
+                  </date>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
     <hr class="rule-large" id="tweets"/>
 
     <div class="grid-row">


### PR DESCRIPTION
This adds public-facing DIT news from DIT's GOV.UK page to the
homepage.