### PR TITLE
Remove file expiry notice on problem report form

### DIFF
--- a/app/views/widgets/_zendesk_footer.html.haml
+++ b/app/views/widgets/_zendesk_footer.html.haml
@@ -2,12 +2,6 @@
   %a{:href => '#feedback', :id => 'feedbackToggle'}
     Is there anything wrong with this page?
   = form_tag('/report_problem', method: :post, class: 'new_problem_report', id: 'new_problem_report') do
-    .notice.notice-link-expiry
-      %i.icon.icon-important
-        %span.visually-hidden Notice
-      %strong.bold-xsmall
-        Download links expire after 15 minutes for security reasons. If you clicked on a link and received an error message,
-        please refresh the page in your browser and try again. If that hasn't fixed your issue, let us know.
     .form-group
       = label_tag('problem_report_goal', 'What were you trying to do?', {:class => 'form-label'})
       = text_area_tag('problem_report_goal', '', {:class => 'form-control', :id => 'problem_report_goal'})


### PR DESCRIPTION
Now that we have a short-term fix for the 15 minute expiry on files, and
a long-term fix is in the works, we no longer need to nag users before
they submit a problem report.