### PR TITLE
Improve resilience of asset URL replacement

### DIFF
--- a/app/models/wp_response.rb
+++ b/app/models/wp_response.rb
@@ -53,7 +53,7 @@ class WpResponse
   end
 
   def s3_asset_url_regex
-    /#{Regexp.quote(s3_asset_bucket_url)}\\\/(.+?)\?(.+?)X-Amz-Signature=[0-9a-f]+/i
+    /#{Regexp.quote(s3_asset_bucket_url)}\\\/(.+?)\?(.+?)X-Amz-Signature(=|%3D)[0-9a-f]+/i
   end
 
   def response_body


### PR DESCRIPTION
Some URLs to S3 assets are Google/MS Outlook encoded garbage and cause the
asset URL replacement regex to be excessively greedy because it doesn't
find a `=` (only `%3D`).