### PR TITLE
Simplify asset proxy URL replacement

### DIFF
--- a/app/models/wp_response.rb
+++ b/app/models/wp_response.rb
@@ -28,7 +28,7 @@ class WpResponse
     # signed S3 URLs with the equivalent URL on our asset proxy.
 
     if replace_s3_urls_with_proxy_urls?
-      response_body.gsub(s3_asset_url_regex, s3_asset_proxy_url + '\/\1')
+      response_body.gsub(s3_asset_bucket_url, s3_asset_proxy_url)
     else
       response_body
     end
@@ -50,10 +50,6 @@ class WpResponse
 
   def replace_s3_urls_with_proxy_urls?
     s3_asset_proxy_url.present?
-  end
-
-  def s3_asset_url_regex
-    /#{Regexp.quote(s3_asset_bucket_url)}\\\/(.+?)\?([^"']+?)X-Amz-Signature(=|%3D)[0-9a-f]+/i
   end
 
   def response_body


### PR DESCRIPTION
We've now had some occurrences of unsigned S3 URLs coming through in the
WP JSON response, which cause the giant ugly regular expression to fail.

This simplifies the search&replace to no longer use a regex looking for
URLs that look like signed S3 URLs, but instead just replace occurrences
of the S3 domain. This means it will catch non-signed S3 URLs (that lack
query parameters), but on the flip side means that signed URLs will now
have the signature query params at the end. As our proxy doesn't care
about these and will silently ignore them, this is a small price to pay
for simplifying this code and no longer having to maintain an awfully
complex regex.