### PR TITLE
Improve error reporting for WP response parsing

### DIFF
--- a/app/models/wp_response.rb
+++ b/app/models/wp_response.rb
@@ -5,6 +5,15 @@ class WpResponse
 
   def to_json
     json = JSON.parse(response_body_with_proxy_urls)
+  rescue JSON::ParserError => e
+    # Provide extra information to aid in debugging
+    Raven.capture_exception(
+      e,
+      request_url: raw_response.effective_url,
+      response_code: raw_response.response_code,
+      response_body: response_body,
+      response_body_with_proxy_urls: response_body_with_proxy_urls
+    )
   end
 
   private


### PR DESCRIPTION
This adds the following to the exception reporting sent through Raven
when a parsing error occurs on WP's JSON response:

- URL requested
- Response HTTP status code
- Raw response body
- Response body with URLs replaced

This will help us debug issues with broken JSON coming back from WP
more effectively.