### PR TITLE
Add last update date/time to index pages

### DIFF
--- a/app/assets/stylesheets/pages/standard/_standard-index.scss
+++ b/app/assets/stylesheets/pages/standard/_standard-index.scss
@@ -11,4 +11,9 @@
 			line-height: 1.25;
 		}
 	}
+
+	.post-meta {
+		display: block;
+		margin-top: 5px;
+	}
 }

--- a/app/views/standard/index.html.haml
+++ b/app/views/standard/index.html.haml
@@ -57,5 +57,10 @@
                   = link_to( title, link)
               %p
                 = content["acf"]["excerpt"]
+                %br
+                %span.post-meta
+                  Updated
+                  = get_date(content['modified'])
+
 
 = render partial: "widgets/zendesk_footer"


### PR DESCRIPTION
Index pages should display when their child pages have last been updated
so that users can see at a glance if there is anything new going on.