### PR TITLE
Docker performance improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,12 @@ version: '3'
 services:
   web:
     build: .
-    command: bundle exec rails s -p 4000 -b '0.0.0.0'
+    # The pidfile often ends up not being deleted on shutdown, there's no reason to
+    # keep it around in an ephemeral Docker container anyway, so set it to /dev/null
+    command: bundle exec rails s -p 4000 -b '0.0.0.0' -P /dev/null
     env_file: .env
     volumes:
-      - .:/workspace
+      # Volume set to `delegated` to improve performance (container FS authoritative)
+      - .:/workspace:delegated
     ports:
       - "4000:4000"


### PR DESCRIPTION
Workspace uses Docker (and Docker Compose) for local development.
This improves performance (particularly on macOS) and generally
improves the local experience by:

- Setting container volumes to delegated (which means that rather
  than guaranteeing consistency all the time, Docker will consider
  the container file system as authoritative and changes may take
  a split second to propagate onto the host file system, which is
  perfectly fine for our use case) - this massively improves IO
  performance on macOS
- Making Rails write its Pidfile to /dev/null (because it rarely
  managed to clean up after itself properly)