### PR TITLE
Implement UX review "quick win" recommendations

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -61,7 +61,7 @@
 				padding-top: 9px;
 				padding-right: 15px;
 				&.js-hidden {
-					color: $brand_color_a;
+					color: $brand_color_c;
 					visibility: visible;
 				}
 			}
@@ -248,7 +248,7 @@
 			#proposition-links {
 				li:first-child {
 					a {
-						color: $brand_color_a;
+						color: $brand_color_c;
 					}
 				}
 			}
@@ -262,7 +262,7 @@
 			#proposition-links {
 				li:nth-child(3) {
 					a {
-						color: $brand_color_a;
+						color: $brand_color_c;
 					}
 				}
 			}
@@ -276,7 +276,7 @@
 			#proposition-links {
 				li:nth-child(4) {
 					a {
-						color: $brand_color_a;
+						color: $brand_color_c;
 					}
 				}
 			}
@@ -290,7 +290,7 @@
 			#proposition-links {
 				li:nth-child(5) {
 					a {
-						color: $brand_color_a;
+						color: $brand_color_c;
 					}
 				}
 			}

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -92,12 +92,12 @@
 		display: inline-block;
 
 		&:link {
-			color: $brand_color_a;
+			color: $govuk-link-color;
 			text-decoration: underline;
 		}
 
 		&:hover {
-			color: $brand_color_a;
+			color: $govuk-link-color;
 			text-decoration: none;
 		}
 	}
@@ -134,7 +134,7 @@
 				margin: 0px;
 			}
 			&:visited {
-				color: $brand_color_a;
+				color: $govuk-link-color;
 			}
 			.link-title {
 				position: relative;
@@ -168,7 +168,7 @@
 				margin: 0px;
 			}
 			&:visited {
-				color: $brand_color_a;
+				color: $govuk-link-color;
 			}
 			.link-title {
 				position: relative;

--- a/app/assets/stylesheets/components/_people-finder.scss
+++ b/app/assets/stylesheets/components/_people-finder.scss
@@ -36,9 +36,7 @@
 		display: none;
 		width: 31%;
 		float: right;
-		background: $brand_color_c; /* For unsupported browsers */
-		background: rgba($brand_color_c, 0.3); /* IE8 */
-		-ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=$brand_color_c, endColorstr=$brand_color_c)"; /* IE8 */
+		background: #333333;
 		text-align: right;
 
 		.maginot {

--- a/app/assets/stylesheets/components/_related.scss
+++ b/app/assets/stylesheets/components/_related.scss
@@ -9,4 +9,8 @@
 		margin: 10px 0px 15px 0px;
 		font-size: 14px;
 	}
+
+	a {
+		font-size: 16px;
+	}
 }

--- a/app/assets/stylesheets/pages/accordion/_accordion.scss
+++ b/app/assets/stylesheets/pages/accordion/_accordion.scss
@@ -14,7 +14,7 @@
 		margin-top: 0px;
 		margin-bottom: 5px;
 		cursor: pointer;
-		color: $brand_color_a;
+		color: $govuk-link-color;
 		padding-right: 30px;
 
 		&:after {
@@ -70,5 +70,5 @@
 
 .accordion-open-all {
 	cursor: pointer;
-		color: $brand_color_a;
+	color: $govuk-link-color;
 }

--- a/app/assets/stylesheets/pages/home/_homepage.scss
+++ b/app/assets/stylesheets/pages/home/_homepage.scss
@@ -178,7 +178,7 @@
 }
 
 #homepage .quick-links {
-  border-top: 5px solid $brand_color_a;
+  border-top: 5px solid $brand_color_c;
   border-bottom: 1px solid $brand_chrome_b;
   padding: 30px;
   margin-bottom: 30px;

--- a/app/assets/stylesheets/util/_links.scss
+++ b/app/assets/stylesheets/util/_links.scss
@@ -4,21 +4,20 @@ a {
 	cursor: pointer;
 
 	&:link {
-		color: $brand_color_a;
+		color: $govuk-link-color;
 		text-decoration: underline;
 	}
 
 	&:hover {
-		color: $brand_color_a;
-		text-decoration: none;
+		color: $govuk-link-color;
 	}
 
 	&:active {
-		color: $brand_color_a;
+		color: $govuk-link-color;
 	}
 
 	&:visited {
-		color: $brand_color_b;
+		color: $govuk-link-visited-color;
 	}
 
 	// Heading links

--- a/app/assets/stylesheets/vars/_colours.scss
+++ b/app/assets/stylesheets/vars/_colours.scss
@@ -11,3 +11,6 @@ $brand_chrome_d: #404040;
 $brand_chrome_e: #6f777b;
 
 $notification_bar_colour: #ffbf47;
+
+$govuk-link-color: #1d70b8;
+$govuk-link-visited-color: #4c2c92;


### PR DESCRIPTION
- Change profile bar to grey background
    The transparent red background lets too much of the pattern beneath
    through, leading to poor legibility
- Replace orange links with GOV.UK link colour/brand red
    The orange link colour is neither on brand nor does it provide
    decent contrast. This changes all links to current GOV.UK link blue
    and the header "active" link to brand red
- Decrease related content link font size