### PR TITLE
Enable redirection functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Metrics/BlockLength:
 
 Metrics/LineLength:
   Max: 100
+
+Metrics/MethodLength:
+  Max: 15

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,14 @@ class ApplicationController < ActionController::Base
   def load_people_finder_profile
     @people_finder_profile = PeopleFinderProfile.from_api(current_user)
   end
+
+  def redirect_from_content!
+    return if @content.blank?
+
+    wp_redirect = @content.first.dig('acf', 'redirect_url').presence || {}
+    wp_redirect_url = wp_redirect['url']
+    return if wp_redirect_url.blank?
+
+    redirect_to(wp_redirect_url)
+  end
 end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -13,9 +13,11 @@ class ContentController < ApplicationController
   def content
     @slug = current_url_without_parameters.split('/').last
     @api_call = ContentSingleQuery.new(@slug)
-    @content = @api_call.type_query
 
-    render file: '/public/404.html', status: 404 if @content.empty?
+    @content = @api_call.type_query
+    raise ActionController::RoutingError, 'Not Found' if @content.empty?
+
+    return if redirect_from_content!
 
     @global_notifications = @api_call.type_query
     @global_notification = @global_notifications.first if @global_notifications.first.is_a?(Hash)

--- a/app/controllers/standard_controller.rb
+++ b/app/controllers/standard_controller.rb
@@ -11,7 +11,12 @@ class StandardController < ApplicationController
 
   def standard
     @api_call = StandardQueries.new(@slug)
+
     @content = @api_call.main_query(@slug)
+    raise ActionController::RoutingError, 'Not Found' if @content.empty?
+
+    return if redirect_from_content!
+
     @parent_id = @content.first['id']
     @content_children_content = @api_call.standard_child_content_query(@parent_id)
     @content_children_standard = @api_call.standard_child_standard_query(@parent_id)
@@ -26,7 +31,12 @@ class StandardController < ApplicationController
   def content
     build_global_notification
     @api_call = ContentSingleQuery.new(@slug)
+
     @content = @api_call.type_query
+    raise ActionController::RoutingError, 'Not Found' if @content.empty?
+
+    return if redirect_from_content!
+
     render template: 'content/content'
   end
 


### PR DESCRIPTION
For some reason the functionality to pick up on redirects configured in
the CMS was never implemented. This isn't great, but given the legacy
status of this app and the existing horrible state of the application,
it'll do.