### PR TITLE
Fix People Finder health check

### DIFF
--- a/app/services/custom_health_check.rb
+++ b/app/services/custom_health_check.rb
@@ -20,7 +20,7 @@ class CustomHealthCheck
 
   def check_peoplefinder_api
     response = Typhoeus.get(
-      "#{URI.join(ENV['PEOPLEFINDER_API_URL'], '/api/people')}?email=something-random",
+      "#{URI.join(ENV['PEOPLEFINDER_API_URL'], '/api/people')}?ditsso_user_id=does-not-exist",
       headers: {
         'Authorization' => "Token token=#{ENV['PEOPLEFINDER_AUTH_TOKEN']}"
       }


### PR DESCRIPTION
The health check relies on behaviour in People Finder that hasn't
produced meaningful results in a long time, but a recent change
broke it completely.

- Make People Finder health check look up non-existing user by
  `ditsso_user_id`, not email