### PR TITLE
Ensure PF API is not called with blank user ID

### DIFF
--- a/app/models/people_finder_profile.rb
+++ b/app/models/people_finder_profile.rb
@@ -32,6 +32,15 @@ class PeopleFinderProfile
     private
 
     def retrieve_user
+      if @ditsso_user_id.blank?
+        # Ensure we don't call PF API without a user ID
+        # TODO: Figure out when this is being called, as it shouldn't be
+        @links = {}
+        @attributes = {}
+
+        return
+      end
+
       response = Typhoeus.get(
         "#{URI.join(BASE_URL, '/api/people')}?ditsso_user_id=#{@ditsso_user_id}",
         headers: {

--- a/spec/models/people_finder_profile_spec.rb
+++ b/spec/models/people_finder_profile_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe PeopleFinderProfile do
   describe '#from_api' do
-    let(:user) { AuthUser.new(email: 'alice@example.com') }
+    let(:user) { AuthUser.new(email: 'alice@example.com', ditsso_user_id: 'alice') }
 
     subject { described_class.from_api(user) }
 


### PR DESCRIPTION
We have changed People Finder to require a user ID being passed into the
people API, and this has unearthed that this app very frequently calls
it without one.

We need to figure out why this is happening, but until then, this stops
the API being called if there is no user ID to call it with.