### PR TITLE
Remove `readthis` and other unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,8 @@ source 'https://rubygems.org'
 gem 'rails', '~> 6.0.0'
 
 gem 'haml-rails', '~> 2.0'
-gem 'jbuilder', '~> 2.5'
-gem 'json'
 gem 'omniauth-oauth2'
 gem 'puma', '~> 4.2'
-gem 'readthis'
 gem 'redis'
 gem 'sass-rails', '~> 6.0'
 gem 'twitter'
@@ -22,7 +19,6 @@ gem 'zendesk_api'
 gem 'govuk_elements_rails'
 gem 'govuk_template'
 
-gem 'foreman'
 gem 'health_check'
 gem 'sentry-raven'
 
@@ -34,7 +30,6 @@ gem 'rails_semantic_logger'
 gem 'sprockets', '~> 3.7'
 
 group :development, :test do
-  gem 'awesome_print'
   gem 'bundler-audit'
   gem 'byebug'
   gem 'capybara', '~> 2.13'
@@ -42,13 +37,6 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-rails', '~> 3.9'
   gem 'rubocop', '~> 0.76.0', require: false
-end
-
-group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    awesome_print (1.8.0)
-    bindex (0.8.1)
     buftok (0.2.0)
     builder (3.2.4)
     bundler-audit (0.6.1)
@@ -77,7 +75,6 @@ GEM
     childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -97,7 +94,6 @@ GEM
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
-    foreman (0.86.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_elements_rails (3.1.3)
@@ -140,14 +136,7 @@ GEM
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
     jaro_winkler (1.5.4)
-    jbuilder (2.9.1)
-      activesupport (>= 4.2.0)
-    json (2.2.0)
     jwt (2.2.1)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -231,9 +220,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    readthis (2.2.0)
-      connection_pool (~> 2.1)
-      redis (>= 3.0, < 5.0)
     redis (4.1.3)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
@@ -260,7 +246,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    ruby_dep (1.5.0)
     ruby_parser (3.14.1)
       sexp_processor (~> 4.9)
     rubyzip (2.0.0)
@@ -289,10 +274,6 @@ GEM
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.13.0)
     simple_oauth (0.3.1)
-    spring (2.1.0)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -326,11 +307,6 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     vcr (5.0.0)
-    web-console (4.0.1)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -352,39 +328,30 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print
   bundler-audit
   byebug
   capybara (~> 2.13)
   dotenv-rails
-  foreman
   govuk_elements_rails
   govuk_template
   haml-rails (~> 2.0)
   health_check
-  jbuilder (~> 2.5)
-  json
-  listen (>= 3.0.5, < 3.2)
   omniauth-oauth2
   pry
   puma (~> 4.2)
   rails (~> 6.0.0)
   rails_semantic_logger
-  readthis
   redis
   rspec-rails (~> 3.9)
   rubocop (~> 0.76.0)
   sass-rails (~> 6.0)
   selenium-webdriver
   sentry-raven
-  spring
-  spring-watcher-listen (~> 2.0.0)
   sprockets (~> 3.7)
   twitter
   typhoeus
   uglifier (>= 1.3.0)
   vcr
-  web-console (>= 3.3.0)
   webmock
   zendesk_api
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,16 +32,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # `config.assets.precompile` and `config.assets.version`
-  # have moved to config/initializers/assets.rb
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
@@ -71,27 +61,10 @@ Rails.application.configure do
     )
   end
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "digital-workspace_#{Rails.env}"
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  config.cache_store = :readthis_store, {
-    expires_in: 90.minutes.to_i,
-    namespace: 'workspace:cache:',
-    redis: { url: URI.join(ENV.fetch('REDIS_URL'), '/o/cache').to_s }
-  }
 end


### PR DESCRIPTION
We should be using the Rails built-in Redis caching integration which
makes the `readthis` gem unnecessary.

Also removes other unused gems.