### PR TITLE
Use CloudFoundry services instead of env var for Redis URL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - config/initializers/*
     - db/schema.rb
+    - lib/vcap_services.rb
     - spec/spec_helper.rb
     - bin/*
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,13 +29,6 @@ module DigitalWorkspace
 
     config.gtm_id = ENV['GTM_ID']
     config.gtm_extra = ENV['GTM_EXTRA']
-    config.redis_cache_url = ENV['REDIS_URL']
-
-    # Caching and sessions
-    config.cache_store = :redis_cache_store, { url: config.redis_cache_url }
-    config.session_store :cache_store,
-                         key: 'workspace_session',
-                         expire_after: 1.hour,
-                         httponly: true
+    config.redis_cache_url = ENV['REDIS_URL'] # Overridden in production config
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
+require 'vcap_services'
+
 Rails.application.configure do
+  # CloudFoundry Services
+  vcap_services = VcapServices.new(ENV['VCAP_SERVICES'])
+  config.redis_cache_url = vcap_services.named_service_url(:redis, 'redis5-workspace')
+
+  # Production caching and sessions through Redis Cache
+  config.cache_store = :redis_cache_store, { url: config.redis_cache_url }
+  config.session_store :cache_store,
+                       key: 'workspace_session',
+                       expire_after: 1.hour,
+                       httponly: true
+
   config.action_controller.perform_caching = true
   config.active_support.deprecation = :notify
   config.assets.compile = false

--- a/lib/vcap_services.rb
+++ b/lib/vcap_services.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Retrieve service URLs from CloudFoundry VCAP_SERVICES
+class VcapServices
+  def initialize(vcap_services_env)
+    @services = JSON.parse(vcap_services_env)
+  end
+
+  def service_url(service_type)
+    candidates = services_of_type(service_type)
+    raise "VCAP_SERVICES has no services of type '#{service_type}'" if candidates.blank?
+
+    candidates.first.dig('credentials', 'uri')
+  end
+
+  def named_service_url(service_type, binding_name)
+    # TODO: For some bizarre reason, binding names do not seem to persist reliably on CloudFoundry.
+    #       Until this gets fixed, we need to establish named services by name instead of binding name,
+    #       which means we need to disregard the last part of the name (which is usually an environment
+    #       suffix).
+    candidates = services_of_type(service_type).select { |service| service['name'].start_with?(binding_name) }
+    raise "VCAP_SERVICES has no '#{binding_name}' services of type '#{service_type}'" if candidates.blank?
+
+    candidates.first.dig('credentials', 'uri')
+  end
+
+  private
+
+  def services_of_type(service_type)
+    @services[service_type.to_s] || []
+  end
+end


### PR DESCRIPTION
The URL for Redis should be read from `VCAP_SERVICES` instead of being
manually set in `REDIS_URL`.

- Add `VcapServices` helper library from People Finder
- Configure Redis through `VcapServices`