### PR TITLE
Health check should use correct Redis URL

### DIFF
--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -12,5 +12,5 @@ HealthCheck.setup do |config|
     CustomHealthCheck.perform_check
   end
 
-  config.redis_url = ENV['REDIS_URL']
+  config.redis_url = Rails.configuration.redis_cache_url
 end


### PR DESCRIPTION
This was still using the environment variable instead
of Rails configuration.